### PR TITLE
specified opencv version 3.1.0.4 to get around inputMask error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
  FROM jupyter/scipy-notebook:033056e6d164
  
- RUN pip install opencv-python
+ RUN pip install opencv-python==3.1.0.4


### PR DESCRIPTION
specifies version number in Dockerfile, fixes issue #1 